### PR TITLE
Add JUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@
 
 2. Import the project as a *Maven* project in Eclipse or IntelliJ.
 3. Set your API key in the _APPLITOOLS_API_KEY_ env variable. Get an API key by logging into Applitools > Person Icon > My API Key
-4. Click the 'Run' button in Eclipse/IntelliJ
+4. Run 'mvn -Dtest=AppTest test' or click the 'Run' button in Eclipse/IntelliJ
 
 Read more here: https://www.applitools.com/tutorials/selenium-java.html

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,22 @@
 	<name>Java-tutorial</name>
 	<url>http://maven.apache.org</url>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M4</version>
+			</plugin>
+
+		</plugins>
+	</build>
+
+	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
+
 	<dependencies>
 		<!-- This is the Applitools Selenium Java SDK -->
 		<dependency>
@@ -16,5 +32,12 @@
 		 <artifactId>eyes-selenium-java3</artifactId>
 		 <version>RELEASE</version>
 		</dependency>
+		<dependency>
+	            <groupId>org.junit.jupiter</groupId>
+	            <artifactId>junit-jupiter-engine</artifactId>
+	            <version>5.6.2</version>
+	            <scope>test</scope>
+	        </dependency>
+
 	</dependencies>
 </project>

--- a/src/test/java/com/applitools/quickstarts/AppTest.java
+++ b/src/test/java/com/applitools/quickstarts/AppTest.java
@@ -13,13 +13,15 @@ import com.applitools.eyes.visualgrid.services.VisualGridRunner;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for simple App.
  */
 public class AppTest {
 
-	public static void main(String[] args) {
+	@Test
+	public void test() {
 		// Create a new chrome web driver
 		WebDriver webDriver = new ChromeDriver();
 
@@ -72,29 +74,23 @@ public class AppTest {
 
 	public static void ultraFastTest(WebDriver webDriver, Eyes eyes) {
 
-		try {
+		// Navigate to the url we want to test
+		webDriver.get("https://demo.applitools.com");
 
-			// Navigate to the url we want to test
-			webDriver.get("https://demo.applitools.com");
+		// Call Open on eyes to initialize a test session
+		eyes.open(webDriver, "Demo App", "Ultrafast grid demo", new RectangleSize(800, 600));
 
-			// Call Open on eyes to initialize a test session
-			eyes.open(webDriver, "Demo App", "Ultrafast grid demo", new RectangleSize(800, 600));
+		// check the login page with fluent api, see more info here
+		// https://applitools.com/docs/topics/sdk/the-eyes-sdk-check-fluent-api.html
+		eyes.check(Target.window().fully().withName("Login page"));
 
-			// check the login page with fluent api, see more info here
-			// https://applitools.com/docs/topics/sdk/the-eyes-sdk-check-fluent-api.html
-			eyes.check(Target.window().fully().withName("Login page"));
+		webDriver.findElement(By.id("log-in")).click();
 
-			webDriver.findElement(By.id("log-in")).click();
+		// Check the app page
+		eyes.check(Target.window().fully().withName("App page"));
 
-			// Check the app page
-			eyes.check(Target.window().fully().withName("App page"));
-
-			// Call Close on eyes to let the server know it should display the results
-			eyes.closeAsync();
-			
-		} catch (Exception e) {
-			eyes.abortAsync();
-		}
+		// Call Close on eyes to let the server know it should display the results
+		eyes.closeAsync();
 
 	}
 	


### PR DESCRIPTION
Add dependency for JUnit and implement @Test to make possibility run test from CLI with 'mvn -Dtest=AppTest test'. Without this update I don't see way how to run tests from CLI, it's possible from IDE only. 
Also maven-surefire-plugin need for this.
Extra try-catch removed due to avoid test pass when it was exception. For example if not set right ApiKey test will pass without any exception message if try-catch remain.